### PR TITLE
fix: update system.text.json package due to vulnerability

### DIFF
--- a/ResoniteAccountDownloader/ResoniteAccountDownloader.csproj
+++ b/ResoniteAccountDownloader/ResoniteAccountDownloader.csproj
@@ -107,7 +107,7 @@
 
     <!-- Reference some dependencies that Elements.Core/SkyFrost needs -->
     <!-- TODO: Is there a smarterway to include them? -->
-    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="System.Security.Permissions" Version="8.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
     <PackageReference Include="Octokit" Version="9.0.0" />


### PR DESCRIPTION
This updates the package version of `System.Text.Json` to `8.0.4` due to the found vulnerability by Microsoft.